### PR TITLE
Fixed updating parcels (PUT) in SendCloud Api wrapper

### DIFF
--- a/src/SendCloudApi.php
+++ b/src/SendCloudApi.php
@@ -367,7 +367,7 @@ class SendCloudApiParcelsResource extends SendCloudApiAbstractResource {
 	
 	protected $resource = 'parcels';
 	protected $create_resource = 'parcel';
-	protected $update_resource = 'parcels';
+	protected $update_resource = 'parcel';
 	protected $list_resource = 'parcels';
 	protected $single_resource = 'parcel';
 	


### PR DESCRIPTION
Fixes "Parcel ID is missing. Quitting process" on PUT request with correct data.
