### PR TITLE
Update SendCloudApi.php

### DIFF
--- a/src/SendCloudApi.php
+++ b/src/SendCloudApi.php
@@ -450,7 +450,7 @@ abstract class SendCloudApiAbstractResource {
 class SendCloudApiParcelsResource extends SendCloudApiAbstractResource {
 
 	protected $resource = 'parcels';
-	protected $create_resource = 'parcel';
+	protected $create_resource = 'parcels';
 	protected $update_resource = 'parcel';
 	protected $list_resource = 'parcels';
 	protected $single_resource = 'parcel';


### PR DESCRIPTION
Shouldn't the create_resource of parcels be 'parcels' in stead of 'parcel'
According to: https://docs.sendcloud.sc/api/v2/index.html#parcel-new